### PR TITLE
Add HTML5 doctype to prevent rendering bugs

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 	<head>


### PR DESCRIPTION
This fix is really straight-forward. By adding the HTML5 doctype, browsers will not use a legacy rendering mode. Notably, this fixes a rendering issue in Firefox 40.0 on OSX where the contents of the body would be a few pixels too large, necessitating a vertical scroll bar.
