### PR TITLE
Added support for the latest MongoDB Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,12 @@ Once you've done that, your config section should look like:
 ``` json
 {
   "type": "mongodb",
-  "connectionUrl": "mongodb://localhost:27017/database"
+  "connectionUrl": "mongodb://localhost:27017",
+  "connectionName": "database"
 }
 ```
 
-You can also just set the environment variable for `DATABASE_URL` to your database connection url.
+You can also just set the environment variable for `DATABASE_URL` to your server connection url and `DATABASE_NAME` for your database name.
 
 Unlike with postgres you do NOT have to create the table in your mongo database prior to running.
 

--- a/lib/document_stores/mongodb.js
+++ b/lib/document_stores/mongodb.js
@@ -1,21 +1,20 @@
-
-
-var MongoClient = require('mongodb').MongoClient,
+const MongoClient = require('mongodb').MongoClient,
     winston = require('winston');
 
-var MongoDocumentStore = function (options) {
+const MongoDocumentStore = function (options) {
     this.expire = options.expire;
-    this.connectionUrl = process.env.DATABASE_URl || options.connectionUrl;
+    this.connectionUrl = process.env.DATABASE_URL || options.connectionUrl;
+    this.connectionName = process.env.DATABASE_NAME || options.connectionName;
 };
 
 MongoDocumentStore.prototype.set = function (key, data, callback, skipExpire) {
-    var now = Math.floor(new Date().getTime() / 1000),
+    const now = Math.floor(new Date().getTime() / 1000),
         that = this;
 
     this.safeConnect(function (err, db) {
         if (err)
             return callback(false);
-        
+
         db.collection('entries').update({
             'entry_id': key,
             $or: [
@@ -40,13 +39,13 @@ MongoDocumentStore.prototype.set = function (key, data, callback, skipExpire) {
 };
 
 MongoDocumentStore.prototype.get = function (key, callback, skipExpire) {
-    var now = Math.floor(new Date().getTime() / 1000),
+    const now = Math.floor(new Date().getTime() / 1000),
         that = this;
 
     this.safeConnect(function (err, db) {
         if (err)
             return callback(false);
-        
+
         db.collection('entries').findOne({
             'entry_id': key,
             $or: [
@@ -75,12 +74,12 @@ MongoDocumentStore.prototype.get = function (key, callback, skipExpire) {
 };
 
 MongoDocumentStore.prototype.safeConnect = function (callback) {
-    MongoClient.connect(this.connectionUrl, function (err, db) {
+    MongoClient.connect(this.connectionUrl, function (err, client) {
         if (err) {
             winston.error('error connecting to mongodb', { error: err });
             callback(err);
         } else {
-            callback(undefined, db);
+            callback(undefined, client.db(this.connectionDBName));
         }
     });
 };

--- a/lib/document_stores/mongodb.js
+++ b/lib/document_stores/mongodb.js
@@ -15,16 +15,18 @@ MongoDocumentStore.prototype.set = function (key, data, callback, skipExpire) {
         if (err)
             return callback(false);
 
-        db.collection('entries').update({
+        db.collection('entries').updateOne({
             'entry_id': key,
             $or: [
                 { expiration: -1 },
                 { expiration: { $gt: now } }
             ]
         }, {
-            'entry_id': key,
-            'value': data,
-            'expiration': that.expire && !skipExpire ? that.expire + now : -1
+            $set: {
+                'entry_id': key,
+                'value': data,
+                'expiration': that.expire && !skipExpire ? that.expire + now : -1
+            }
         }, {
             upsert: true
         }, function (err, existing) {
@@ -61,7 +63,7 @@ MongoDocumentStore.prototype.get = function (key, callback, skipExpire) {
             callback(entry === null ? false : entry.value);
 
             if (entry !== null && entry.expiration !== -1 && that.expire && !skipExpire) {
-                db.collection('entries').update({
+                db.collection('entries').updateOne({
                     'entry_id': key
                 }, {
                     $set: {
@@ -74,7 +76,7 @@ MongoDocumentStore.prototype.get = function (key, callback, skipExpire) {
 };
 
 MongoDocumentStore.prototype.safeConnect = function (callback) {
-    MongoClient.connect(this.connectionUrl, function (err, client) {
+    MongoClient.connect(this.connectionUrl, { useUnifiedTopology: true }, function (err, client) {
         if (err) {
             winston.error('error connecting to mongodb', { error: err });
             callback(err);

--- a/lib/document_stores/mongodb.js
+++ b/lib/document_stores/mongodb.js
@@ -81,7 +81,7 @@ MongoDocumentStore.prototype.safeConnect = function (callback) {
             winston.error('error connecting to mongodb', { error: err });
             callback(err);
         } else {
-            callback(undefined, client.db(this.connectionDBName));
+            callback(undefined, client.db(this.connectionName));
         }
     });
 };

--- a/lib/document_stores/mongodb.js
+++ b/lib/document_stores/mongodb.js
@@ -1,5 +1,5 @@
-const MongoClient = require('mongodb').MongoClient,
-    winston = require('winston');
+const { MongoClient } = require("mongodb"),
+    winston = require("winston");
 
 const MongoDocumentStore = function (options) {
     this.expire = options.expire;
@@ -8,82 +8,103 @@ const MongoDocumentStore = function (options) {
 };
 
 MongoDocumentStore.prototype.set = function (key, data, callback, skipExpire) {
-    const now = Math.floor(new Date().getTime() / 1000),
-        that = this;
+    const now = Math.floor(new Date().getTime() / 1000);
 
-    this.safeConnect(function (err, db) {
-        if (err)
-            return callback(false);
+    this.safeConnect((err, db, client) => {
+        if (err) return callback(false);
 
-        db.collection('entries').updateOne({
-            'entry_id': key,
-            $or: [
-                { expiration: -1 },
-                { expiration: { $gt: now } }
-            ]
-        }, {
-            $set: {
-                'entry_id': key,
-                'value': data,
-                'expiration': that.expire && !skipExpire ? that.expire + now : -1
+        db.collection("entries").updateOne(
+            {
+                entry_id: key,
+                $or: [{ expiration: -1 }, { expiration: { $gt: now } }],
+            },
+            {
+                $set: {
+                    entry_id: key,
+                    value: data,
+                    expiration:
+                        this.expire && !skipExpire ? this.expire + now : -1,
+                },
+            },
+            {
+                upsert: true,
+            },
+            (err /*, existing*/) => {
+                client.close();
+
+                if (err) {
+                    winston.error("error persisting value to mongodb", {
+                        error: err,
+                    });
+                    return callback(false);
+                }
+
+                callback(true);
             }
-        }, {
-            upsert: true
-        }, function (err, existing) {
-            if (err) {
-                winston.error('error persisting value to mongodb', { error: err });
-                return callback(false);
-            }
-
-            callback(true);
-        });
+        );
     });
 };
 
 MongoDocumentStore.prototype.get = function (key, callback, skipExpire) {
-    const now = Math.floor(new Date().getTime() / 1000),
-        that = this;
+    const now = Math.floor(new Date().getTime() / 1000);
 
-    this.safeConnect(function (err, db) {
-        if (err)
-            return callback(false);
+    this.safeConnect((err, db, client) => {
+        if (err) return callback(false);
 
-        db.collection('entries').findOne({
-            'entry_id': key,
-            $or: [
-                { expiration: -1 },
-                { expiration: { $gt: now } }
-            ]
-        }, function (err, entry) {
-            if (err) {
-                winston.error('error persisting value to mongodb', { error: err });
-                return callback(false);
+        db.collection("entries").findOne(
+            {
+                entry_id: key,
+                $or: [{ expiration: -1 }, { expiration: { $gt: now } }],
+            },
+            (err, entry) => {
+                if (err) {
+                    winston.error("error persisting value to mongodb", {
+                        error: err,
+                    });
+                    client.close();
+                    return callback(false);
+                }
+
+                callback(entry === null ? false : entry.value);
+
+                if (
+                    entry !== null &&
+                    entry.expiration !== -1 &&
+                    this.expire &&
+                    !skipExpire
+                ) {
+                    db.collection("entries").updateOne(
+                        {
+                            entry_id: key,
+                        },
+                        {
+                            $set: {
+                                expiration: this.expire + now,
+                            },
+                        },
+                        () => {
+                            client.close();
+                        }
+                    );
+                }
             }
-
-            callback(entry === null ? false : entry.value);
-
-            if (entry !== null && entry.expiration !== -1 && that.expire && !skipExpire) {
-                db.collection('entries').updateOne({
-                    'entry_id': key
-                }, {
-                    $set: {
-                        'expiration': that.expire + now
-                    }
-                }, function (err, result) { });
-            }
-        });
+        );
     });
 };
 
 MongoDocumentStore.prototype.safeConnect = function (callback) {
-    MongoClient.connect(this.connectionUrl, { useUnifiedTopology: true }, function (err, client) {
-        if (err) {
-            winston.error('error connecting to mongodb', { error: err });
-            callback(err);
-        } else {
-            callback(undefined, client.db(this.connectionName));
+    MongoClient.connect(
+        this.connectionUrl,
+        { useUnifiedTopology: true },
+        (err, client) => {
+            if (err) {
+                winston.error("error connecting to mongodb", { error: err });
+                callback(err);
+            } else {
+                callback(undefined, client.db(this.connectionName), client);
+            }
         }
-    });
+    );
 };
 
 module.exports = MongoDocumentStore;


### PR DESCRIPTION
Starting from version 3 of MongoDB Driver, you need to separately specify the connection address and select the table using `client.db('db_name')`