### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM node:14.8.0-stretch
 RUN mkdir -p /usr/src/app && \
     chown node:node /usr/src/app
 
-USER node:node 
+USER node:node
 
 WORKDIR /usr/src/app
 
-COPY --chown=node:node . . 
+COPY --chown=node:node . .
 
 RUN npm install && \
     npm install redis@0.8.1 && \
@@ -25,7 +25,7 @@ ENV STORAGE_TYPE=memcached \
     STORAGE_AWS_REGION= \
     STORAGE_USENAMER= \
     STORAGE_PASSWORD= \
-    STORAGE_FILEPATH= 
+    STORAGE_FILEPATH=
 
 ENV LOGGING_LEVEL=verbose \
     LOGGING_TYPE=Console \
@@ -47,11 +47,11 @@ ENV RATELIMITS_NORMAL_TOTAL_REQUESTS=500\
     RATELIMITS_WHITELIST_EVERY_MILLISECONDS=  \
     # comma separated list for the whitelisted \
     RATELIMITS_WHITELIST=example1.whitelist,example2.whitelist \
-    \   
+    \
     RATELIMITS_BLACKLIST_TOTAL_REQUESTS= \
     RATELIMITS_BLACKLIST_EVERY_MILLISECONDS= \
     # comma separated list for the blacklisted \
-    RATELIMITS_BLACKLIST=example1.blacklist,example2.blacklist 
+    RATELIMITS_BLACKLIST=example1.blacklist,example2.blacklist
 ENV DOCUMENTS=about=./about.md
 
 EXPOSE ${PORT}


### PR DESCRIPTION
Dockerfile contained useless trailing whitespaces, which could generate
"ghost" diffs.