### PR TITLE
Fixes #376 + .dockerignore improvement

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+Dockerfile
+.git
 npm-debug.log
 node_modules
 *.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,5 +59,10 @@ STOPSIGNAL SIGINT
 ENTRYPOINT [ "bash", "docker-entrypoint.sh" ]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s \
-    --retries=3 CMD [ "curl" , "-f" "localhost:${PORT}", "||", "exit", "1"]
+    --retries=3 CMD [ "sh", "-c", "echo -n 'curl localhost:7777... '; \
+    (\
+        curl -sf localhost:7777 > /dev/null\
+    ) && echo OK || (\
+        echo Fail && exit 2\
+    )"]
 CMD ["npm", "start"]


### PR DESCRIPTION
Fixes #376 + .dockerignore improvement

Healthcheck syntax repaired, health check should run successfully now.
`.dockerignore` entries added so that `git` operations and `Dockerfile` editing will not invalidate build step #5 (`COPY`)