### PR TITLE
Parse the expiration time as an INT

### DIFF
--- a/lib/document_stores/postgres.js
+++ b/lib/document_stores/postgres.js
@@ -10,7 +10,6 @@ var PostgresDocumentStore = function (options) {
   this.expireJS = parseInt(options.expire);
 
   const connectionString = process.env.DATABASE_URL || options.connectionUrl;
-  console.log(connectionString)
   this.pool = new Pool({connectionString});
 };
 

--- a/lib/document_stores/postgres.js
+++ b/lib/document_stores/postgres.js
@@ -7,7 +7,7 @@ const {Pool} = require('pg');
 
 // A postgres document store
 var PostgresDocumentStore = function (options) {
-  this.expireJS = parseInt(options.expire);
+  this.expireJS = parseInt(options.expire, 10);
 
   const connectionString = process.env.DATABASE_URL || options.connectionUrl;
   this.pool = new Pool({connectionString});

--- a/lib/document_stores/postgres.js
+++ b/lib/document_stores/postgres.js
@@ -7,9 +7,10 @@ const {Pool} = require('pg');
 
 // A postgres document store
 var PostgresDocumentStore = function (options) {
-  this.expireJS = options.expire;
+  this.expireJS = parseInt(options.expire);
 
   const connectionString = process.env.DATABASE_URL || options.connectionUrl;
+  console.log(connectionString)
   this.pool = new Pool({connectionString});
 };
 


### PR DESCRIPTION
Using  .ENV files with haste-server causes the expiration time to be seen as a String. This results in the `expireJS` being enormously large and causes a "value is out of range for type integer" error, in probably most databases  (*postgres* in my case).

https://github.com/toptal/haste-server/blob/5d2965ffc5d9b309ef6d4be9e8c2288c83d72c73/lib/document_stores/postgres.js#L27
