### PR TITLE
Add support for additional S3-compatible providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,10 @@ Once you've done that, your config section should look like this:
 }
 ```
 
-Authentication is handled automatically by the client. Check
-[Amazon's documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html)
-for more information. You will need to grant your role these permissions to
-your bucket:
+Authentication can be handled in the config (by adding `keyId` and `keySecret` properties to the above example), or separately by the client SDK. 
+See [Amazon's documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) for more information.
+
+You will need to create an IAM user and retrieve an access key. The IAM user should have the the following permissions:
 
 ```json
 {
@@ -271,6 +271,18 @@ your bucket:
             "Resource": "arn:aws:s3:::your-bucket-name-goes-here/*"
         }
     ]
+}
+```
+
+**Alternative S3 API Providers:** A number of other storage providers support the S3 API (such as Linode, BackBlaze B2, etc). To use one of those providers, you will need to specify an endpoint in your config instead of a region:
+
+```json
+{
+  "type": "amazon-s3",
+  "bucket": "your-bucket-name",
+  "endpoint": "s3.example.backblazeb2.com",
+  "keyId": "9387200",
+  "keySecret": "H93lmz_93hla9jhdl/Example"
 }
 ```
 

--- a/lib/document_stores/amazon-s3.js
+++ b/lib/document_stores/amazon-s3.js
@@ -6,7 +6,16 @@ var winston = require('winston');
 var AmazonS3DocumentStore = function(options) {
   this.expire = options.expire;
   this.bucket = options.bucket;
-  this.client = new AWS.S3({region: options.region});
+
+  var config = {};
+  if(options.endpoint) 
+    config.endpoint = new AWS.Endpoint(options.endpoint);
+  if(options.region)
+    config.region = options.region;
+  if(options.keyId && options.keySecret)
+    config.credentials = new AWS.Credentials({ accessKeyId: options.keyId, secretAccessKey: options.keySecret })
+
+  this.client = new AWS.S3(config);
 };
 
 AmazonS3DocumentStore.prototype.get = function(key, callback, skipExpire) {


### PR DESCRIPTION
This should be a backwards compatible change allowing people to use BackBlaze B2 or Linode with the aws-sdk (as they offer S3 endpoints). 

The key change here is allowing an `endpoint` in the config instead of the `region`. I've also added support for the credentials to be supplied via the config. This is optional, and if credentials are not specified in the config, it will fall back to the previous logic.