### PR TITLE
Delete superfluous network definition

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,8 +2,6 @@ version: '3.0'
 services:
   haste-server:
     build: .
-    networks:
-      - db-network
     environment:
       - STORAGE_TYPE=memcached
       - STORAGE_HOST=memcached
@@ -12,8 +10,3 @@ services:
       - 7777:7777
   memcached:
     image: memcached:latest
-    networks:
-      - db-network
-
-networks:
-  db-network:


### PR DESCRIPTION
No need to define a network when compose files and stackfiles come with their own cross container network defined as `default` superfluous networks add nothing.