### PR TITLE
Add /healthz endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ ENTRYPOINT [ "bash", "docker-entrypoint.sh" ]
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s \
     --retries=3 CMD [ "sh", "-c", "echo -n 'curl localhost:7777... '; \
     (\
-        curl -sf localhost:7777 > /dev/null\
+        curl -sf localhost:7777/healthz > /dev/null\
     ) && echo OK || (\
         echo Fail && exit 2\
     )"]

--- a/server.js
+++ b/server.js
@@ -109,6 +109,11 @@ if (config.rateLimits) {
 
 // first look at API calls
 app.use(route(function(router) {
+  // get healthz
+  router.get("/healthz", function (request, response) {
+    response.writeHead(204);
+    response.end();
+  });
   // get raw documents - support getting with extension
 
   router.get('/raw/:id', function(request, response) {


### PR DESCRIPTION
There is still work to be done here. Ideally, this endpoint should
return information about the document store health, and return a more
informative 200 instead of an empty 204.

Fixes #383