### PR TITLE
Don't track docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.swo
 data
 *.DS_Store
+docker-compose.override.yml


### PR DESCRIPTION
This allows end users who need to build Hastebin for their deployments as an image in a private registry or any other changes without needing to collide with the ability to upgrade their local cached copy of the hastebin repo.