### PR TITLE
Update about.md to fix error

### DIFF
--- a/about.md
+++ b/about.md
@@ -25,7 +25,7 @@ You can even take this a step further, and cut out the last step of copying the
 URL with:
 
 * osx: `cat something | haste | pbcopy`
-* linux: `cat something | haste | xsel`
+* linux: `cat something | haste | xsel -b`
 * windows: check out [WinHaste](https://github.com/ajryan/WinHaste)
 
 After running that, the STDOUT output of `cat something` will show up at a URL


### PR DESCRIPTION
The command `xsel` does not copy to your clipboard, that's what `xsel -b` does. See the [manpage](https://manpages.debian.org/bullseye/xsel/xsel.1x.en.html)