### PR TITLE
Add CODEOWNERS for github workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/workflows @toptal/site-acquisition-eng
+* @toptal/site-acquisition-eng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows @toptal/site-acquisition-eng


### PR DESCRIPTION
We need every workflow file to have a team owner.
The last person's team that was updating workflow file was assigned in this case.