### PR TITLE
V2 - Replace deprecated update() with updateOne()

### DIFF
--- a/src/lib/document-stores/mongo.ts
+++ b/src/lib/document-stores/mongo.ts
@@ -97,15 +97,17 @@ class MongoDocumentStore extends Store {
       return client
         ?.db()
         .collection('entries')
-        .update(
+        .updateOne(
           {
             entry_id: key,
             $or: [{ expiration: -1 }, { expiration: { $gt: now } }]
           },
           {
-            entry_id: key,
-            value: data,
-            expiration: this.expire && !skipExpire ? this.expire + now : -1
+            $set: {
+              entry_id: key,
+              value: data,
+              expiration: this.expire && !skipExpire ? this.expire + now : -1
+            }
           },
           {
             upsert: true


### PR DESCRIPTION
I'm not sure what version mongodb this is meant to use, however, this allows for a fix for driver versions up to 4.1.4.